### PR TITLE
Correct path for the 'module' key in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Redux middleware for Airbrake error logging",
   "main": "dist/redux-middleware.js",
-  "module": "src/index.js",
+  "module": "dist/redux-middleware.js",
   "lock": false,
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
Module resolution fails under Parcel 2 due to an incorrect 'module' key. The index.js is not shipped with the library, so the module key is updated to point to the same file path as 'main'.